### PR TITLE
smooth conveyors

### DIFF
--- a/code/controllers/subsystem/processing/conveyor.dm
+++ b/code/controllers/subsystem/processing/conveyor.dm
@@ -1,0 +1,4 @@
+PROCESSING_SUBSYSTEM_DEF(conveyors)
+	name = "Conveyor Belts"
+	wait = 1
+	stat_tag = "CB"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -808,7 +808,9 @@
 /atom/movable/proc/ConveyorMove(movedir)
 	set waitfor = FALSE
 	if(!anchored && has_gravity())
+		var/old_dir = dir
 		step(src, movedir, min(8, step_size))
+		dir = old_dir
 
 //Returns an atom's power cell, if it has one. Overload for individual items.
 /atom/movable/proc/get_cell()

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -144,8 +144,10 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	RegisterSignal(mover, COMSIG_PARENT_QDELETING, .proc/UnregisterMover)
 	if(!affecting)
 		affecting = list()
-	affecting += mover
-	START_PROCESSING(SSconveyors, src)
+	if(!mover.anchored && mover.has_gravity())
+		affecting += mover
+	if(LAZYLEN(affecting))
+		START_PROCESSING(SSconveyors, src)
 
 /obj/machinery/conveyor/proc/UnregisterMover(atom/movable/mover)
 	UnregisterSignal(mover, COMSIG_PARENT_QDELETING)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -50,12 +50,12 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 
 // create a conveyor
 /obj/machinery/conveyor/Initialize(mapload, newdir, newid)
-	START_PROCESSING(SSconveyors, src)
 	. = ..()
 	if(newdir)
 		setDir(newdir)
 	if(newid)
 		id = newid
+	STOP_PROCESSING(SSfastprocess, src)
 	for(var/i in loc.contents)
 		if(i == src)
 			continue
@@ -145,6 +145,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(!affecting)
 		affecting = list()
 	affecting += mover
+	START_PROCESSING(SSconveyors, src)
 
 /obj/machinery/conveyor/proc/UnregisterMover(atom/movable/mover)
 	UnregisterSignal(mover, COMSIG_PARENT_QDELETING)
@@ -153,6 +154,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	affecting -= mover
 	if(!length(affecting))
 		affecting = null
+		STOP_PROCESSING(SSconveyors, src)
 
 /obj/machinery/conveyor/Crossed(atom/movable/AM, oldloc)
 	. = ..()

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -50,6 +50,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 
 // create a conveyor
 /obj/machinery/conveyor/Initialize(mapload, newdir, newid)
+	START_PROCESSING(SSconveyors, src)
 	. = ..()
 	if(newdir)
 		setDir(newdir)
@@ -63,6 +64,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	LAZYADD(GLOB.conveyors_by_id[id], src)
 
 /obj/machinery/conveyor/Destroy()
+	STOP_PROCESSING(SSconveyors, src)
 	LAZYREMOVE(GLOB.conveyors_by_id[id], src)
 	affecting = null
 	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -294,6 +294,7 @@
 #include "code\controllers\subsystem\vis_overlays.dm"
 #include "code\controllers\subsystem\vote.dm"
 #include "code\controllers\subsystem\weather.dm"
+#include "code\controllers\subsystem\processing\conveyor.dm"
 #include "code\controllers\subsystem\processing\fastprocess.dm"
 #include "code\controllers\subsystem\processing\fields.dm"
 #include "code\controllers\subsystem\processing\fluids.dm"


### PR DESCRIPTION
Puts conveyors on their own subsystem with a wait of 1, fixes most of the jitteriness with them fixes #95 ~~slight issue is that things that aren't being moved by the conveyor are still being added to the affecting list, things like plastic flaps and the supply like blast doors.~~
