### PR TITLE
Slide to the left, Slide to the right

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -7,6 +7,7 @@
 	//PIXEL MOVEMENT VARS
 	var/fx // stores fractional pixel movement in the x
 	var/fy // stores fractional pixel movement in the y
+	var/sliding // currently sliding?
 
 	var/walking = NONE
 	var/move_resist = MOVE_RESIST_DEFAULT
@@ -252,7 +253,15 @@
 	var/atom/oldloc = loc
 
 	. = ..()
-
+	if(!. && !sliding)
+		sliding = TRUE
+		for(var/d in GLOB.cardinals)
+			if(direct & d)
+				. = step(src, d, step_size)
+				if(.)
+					direct = d
+					break
+		sliding = FALSE
 	last_move = direct
 	setDir(direct)
 	if(.)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -122,12 +122,6 @@
 			n = get_step(L, direct)
 
 	. = step(mob, direct, step_size)
-	if(!.)
-		for(var/d in GLOB.cardinals)
-			if(direct & d)
-				. = step(mob, d, step_size)
-				if(.)
-					break
 
 	if(.) // If mob is null here, we deserve the runtime
 		if(mob.throwing)


### PR DESCRIPTION
Moves the Move() code to atom/movable
fixes #89 #108 
still need a way to accomodate for diagonal sliding for situations where you're diagonal of the object you're pulling and moving cardinally 
paint drawn example(it's beautiful I know):
![image](https://user-images.githubusercontent.com/30060146/74626215-f9329f80-511c-11ea-996a-c39d8358c55c.png)
