### PR TITLE
Cleans up some problems with the connect_loc fixes, fixes a semi related stack harddel, I hate .merge()

### DIFF
--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -43,6 +43,8 @@
 
 /// Finds the singleton for the element type given and attaches it to src
 /datum/proc/_AddElement(list/arguments)
+	if(QDELING(src))
+		CRASH("We just tried to add an element to a qdeleted datum, something is fucked")
 	var/datum/element/ele = SSdcs.GetElement(arguments)
 	arguments[1] = src
 	if(ele.Attach(arglist(arguments)) == ELEMENT_INCOMPATIBLE)

--- a/code/datums/elements/caltrop.dm
+++ b/code/datums/elements/caltrop.dm
@@ -4,7 +4,7 @@
  * Used for broken glass, cactuses and four sided dice.
  */
 /datum/element/caltrop
-	element_flags = ELEMENT_BESPOKE
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
 	id_arg_index = 2
 
 	///Minimum damage done when crossed

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -34,7 +34,7 @@
 		unregister_all(listener)
 	else if(targets[tracked.loc]) // Detach can happen multiple times due to qdel
 		unregister_signals(listener, tracked, tracked.loc)
-		UnregisterSignal(tracked, COMSIG_MOVABLE_MOVED)
+		UnregisterSignal(tracked, COMSIG_MOVABLE_LOCATION_CHANGE)
 
 /datum/element/connect_loc/proc/update_signals(datum/listener, atom/movable/tracked)
 	var/existing = length(targets[tracked.loc])
@@ -62,7 +62,7 @@
 				unregister_signals(listener, tracked, location)
 			else
 				continue
-			UnregisterSignal(tracked, COMSIG_MOVABLE_MOVED)
+			UnregisterSignal(tracked, COMSIG_MOVABLE_LOCATION_CHANGE)
 
 /datum/element/connect_loc/proc/unregister_signals(datum/listener, atom/movable/tracked, atom/old_loc)
 	if (length(targets[old_loc]) <= 1)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -63,6 +63,9 @@
 		for(var/obj/item/stack/S in loc)
 			if(can_merge(S))
 				INVOKE_ASYNC(src, .proc/merge, S)
+				//Merge can call qdel on us, so let's be safe yeah?
+				if(QDELETED(src))
+					return
 	var/list/temp_recipes = get_main_recipes()
 	recipes = temp_recipes.Copy()
 	if(material_type)


### PR DESCRIPTION
Fixes the unit test errors, we were unregistering for the WRONG SIGNAL so we tried to remove an element that wasn't there anymore. hhhhhhhhhhhh
Fixes the last few stack harddels, stacks were merging, and the element was being added to already qdel'd
objects, which is why they were all in null space
Adds a sanity check to AddElement to prevent this sort of thing from happening in the future
Adds ELEMENT_DETACH to the caltrop element so it passes destroy stuff along properly